### PR TITLE
Update-index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/ajax/README.md">Meetup description</a>
         <tr>
-           <td><a href="http://gdisf-js-apis.appspot.com/">JS303: Client-side APIs</a>
+           <td><a href="http://teaching-materials.org/apis/">JS303: Client-side APIs</a>
            <td>JS203
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/apis/README.md">Meetup description</a>


### PR DESCRIPTION
# Summary

Fixes issue #247

Here's a description of changes:

*change all these links from http://gdisf-js-apis.appspot.com/ to the correct Github Pages ones for teaching-materials.org "http://teaching-materials.org/apis/"
- ...
- ...

cc @gdisf/admins
change all these links from http://gdisf-js-apis.appspot.com/ to  http://www.teaching-materials.org/apis/
